### PR TITLE
Added error condition for upload_artifact_scan

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,13 +14,7 @@ Quick Start
 
 Several quick start options are available:
 
-- Build locally: 
-
-::
-
-    pip install wheel setuptools
-    python setup.py build
-
+- Build locally: ``pip install wheel setuptools && python setup.py build`` 
 - Install with pip (recommended): ``pip install fortifyapi``
 - `Download the latest release <https://github.com/target/fortifyapi/releases/latest/>`__.
 
@@ -51,4 +45,4 @@ Copyright and License
 ~~~~~~~~~~~~~~~~~~~~~
 .. image:: https://img.shields.io/github/license/target/fortifyapi.svg?style=flat-square
 
-- Copyright 2017 Target Brands, Inc.
+- Copyright 2018 Target Brands, Inc.

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,13 @@ Quick Start
 
 Several quick start options are available:
 
-- Build locally: ``python setup.py build``
+- Build locally: 
+
+::
+
+    pip install wheel setuptools
+    python setup.py build
+
 - Install with pip (recommended): ``pip install fortifyapi``
 - `Download the latest release <https://github.com/target/fortifyapi/releases/latest/>`__.
 

--- a/fortifyapi/fortify.py
+++ b/fortifyapi/fortify.py
@@ -405,7 +405,11 @@ class FortifyApi(object):
         :param project_version_id: project_version_id
         :return: Response from the file upload operation
         """
-        file_token = self.get_file_token('UPLOAD').data['data']['token']
+        upload = self.get_file_token('UPLOAD')
+        if upload == None or upload['data'] == None:
+          return FortifyResponse(message='Failed to get the SSC upload file token', success=False)
+          
+        file_token = upload.data['data']['token']
         url = "/ssc/upload/resultFileUpload.html?mat=" + file_token
         files = {'file': (ntpath.basename(file_path), open(file_path, 'rb'))}
 

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+from setuptools import setup
 
 from fortifyapi import __version__ as version
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 
 import os
 import sys
-from setuptools import setup
 
 from fortifyapi import __version__ as version
 


### PR DESCRIPTION
- Added dependency for installation via building from source (setuptools, wheel)
- Added error condition for upload_scan_artifact failing due to a failure in dependent function get_file_token. When the fortify instance is unreachable the function will throw a Requests exception, leaving the data variable to be `None`, which then cascades down and causes a null reference error in upload_scan_artifact.